### PR TITLE
fix: update Solr URL for dev environment

### DIFF
--- a/page-search-api/src/main/resources/application.properties
+++ b/page-search-api/src/main/resources/application.properties
@@ -12,7 +12,7 @@ searchpages.extractedtext.service.link = http://localhost:8081/textextracted
 # possible values: solr or nutchwax
 # searchpages.textsearch.service.bean = nutchwax
 searchpages.textsearch.service.bean = fusion
-searchpages.textsearch.service.bean.solr.link = http://p82.arquivo.pt:8983/solr/text_index_v6
+searchpages.textsearch.service.bean.solr.link = http://p44.arquivo.pt:2200/solr/pages
 searchpages.textsearch.service.bean.fusion.nutchwax.textsearch.api.link = https://dev.arquivo.pt/textsearchnutchwax
 
 wayback.service.endpoint = https://dev.arquivo.pt/wayback


### PR DESCRIPTION
Update the Solr service link to point to the correct dev instance (p44.arquivo.pt:2200) instead of p82.arquivo.pt:8983