### PR TITLE
ci: add GitHub Actions workflow to build and test with Maven

### DIFF
--- a/.github/workflows/maven-ci.yml
+++ b/.github/workflows/maven-ci.yml
@@ -1,0 +1,25 @@
+name: Maven CI
+
+on:
+  push:
+    branches: [master, development]
+  pull_request:
+    branches: [master, development]
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 8
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '8'
+          cache: maven
+
+      - name: Build and test with Maven
+        run: mvn -B -P '!docker-integration-tests' clean verify


### PR DESCRIPTION
## Summary
- Adds a GitHub Actions workflow (\`.github/workflows/maven-ci.yml\`) that builds the project and runs its Maven test suite on push/PR to \`master\` and \`development\`
- Uses JDK 8 (Temurin), required per the README since the nutchwax legacy dependencies won't build on newer JDKs
- Skips the \`docker-integration-tests\` profile, which needs external Solr/Docker services not available in CI

## Test plan
- [x] Ran \`mvn -B -P '!docker-integration-tests' clean verify\` locally with JDK 8 — all 43 unit tests pass across \`utils\`, \`page-search-api\`, \`page-search-indexer\`
- [ ] Confirm the workflow runs green on GitHub Actions once pushed
