### PR TITLE
test: add missing unit tests for page-search-api

### DIFF
--- a/page-search-api/pom.xml
+++ b/page-search-api/pom.xml
@@ -96,7 +96,7 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>5.14.2</version>
+            <version>4.11.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/page-search-api/pom.xml
+++ b/page-search-api/pom.xml
@@ -94,6 +94,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>5.14.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>pt.arquivo</groupId>
             <artifactId>pwalucene</artifactId>
             <version>1.0.0-SNAPSHOT</version>
@@ -260,6 +266,14 @@
                 <version>3.2.3</version>
                 <configuration>
                     <failOnMissingWebXml>false</failOnMissingWebXml>
+                </configuration>
+            </plugin>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <!-- Mockito's bundled ByteBuddy officially only supports up to Java 24; this environment
+                         runs a newer JDK, so mock class generation needs the experimental flag. -->
+                    <argLine>${argLine} -Dnet.bytebuddy.experimental=true</argLine>
                 </configuration>
             </plugin>
             <plugin>

--- a/page-search-api/src/main/java/pt/arquivo/services/SearchResultSerializer.java
+++ b/page-search-api/src/main/java/pt/arquivo/services/SearchResultSerializer.java
@@ -18,7 +18,7 @@ public class SearchResultSerializer extends JsonSerializer {
     private static final Logger LOG = LoggerFactory.getLogger(SearchResultSerializer.class);
 
     @Value("${searchpages.api.show.ids}")
-    private boolean showIds;
+    boolean showIds;
 
     @Override
     public void serialize(Object o, JsonGenerator jsonGenerator, SerializerProvider serializerProvider) throws IOException {

--- a/page-search-api/src/main/java/pt/arquivo/services/cdx/CDXSearchService.java
+++ b/page-search-api/src/main/java/pt/arquivo/services/cdx/CDXSearchService.java
@@ -38,22 +38,22 @@ public class CDXSearchService {
     private int timeoutConn;
 
     @Value("${wayback.service.cdx.endpoint}")
-    private String waybackCdxEndpoint;
+    String waybackCdxEndpoint;
 
     @Value("${screenshot.service.endpoint}")
-    private String screenshotServiceEndpoint;
+    String screenshotServiceEndpoint;
 
     @Value("${wayback.service.endpoint}")
-    private String waybackServiceEndpoint;
+    String waybackServiceEndpoint;
 
     @Value("${wayback.noframe.service.endpoint}")
-    private String waybackNoFrameServiceEndpoint;
+    String waybackNoFrameServiceEndpoint;
 
     @Value("${searchpages.extractedtext.service.link}")
-    private String extractedTextServiceEndpoint;
+    String extractedTextServiceEndpoint;
 
     @Value("${searchpages.textsearch.service.link}")
-    private String textSearchServiceEndpoint;
+    String textSearchServiceEndpoint;
 
     @Value("${searchpages.api.show.ids}")
     private boolean showIds;
@@ -130,7 +130,7 @@ public class CDXSearchService {
         return searchResult;
     }
 
-    private String generateCdxQuery(String url, String from, String to) {
+    String generateCdxQuery(String url, String from, String to) {
         if (from == null) {
             from = "";
         }
@@ -238,7 +238,7 @@ public class CDXSearchService {
     }
 
 
-    private void populateEndpointsLinks(SearchResultNutchImpl searchResult, boolean textMatch) throws UnsupportedEncodingException {
+    void populateEndpointsLinks(SearchResultNutchImpl searchResult, boolean textMatch) throws UnsupportedEncodingException {
 
         searchResult.setLinkToArchive(waybackServiceEndpoint.concat("/")
                 .concat(searchResult.getTstamp().concat("/").concat(searchResult.getOriginalURL())));

--- a/page-search-api/src/main/java/pt/arquivo/services/cdx/CDXSearchService.java
+++ b/page-search-api/src/main/java/pt/arquivo/services/cdx/CDXSearchService.java
@@ -186,18 +186,7 @@ public class CDXSearchService {
 
         try {
             LOG.debug("[OPEN Connection]: " + strurl);
-            URL url = new URL(strurl);
-            URLConnection con;
-            if (strurl.startsWith("https")) {
-                con = (HttpsURLConnection) url.openConnection();
-            } else {
-                con = url.openConnection();
-            }
-            con.setConnectTimeout(timeoutConn);
-
-            // set this to a globaltimeout equal to all services
-            con.setReadTimeout(timeoutreadConn);
-
+            URLConnection con = openCdxConnection(strurl);
             is = con.getInputStream();
             BufferedReader rd = new BufferedReader(new InputStreamReader(is, Charset.forName("UTF-8")));
             jsonResponse = readAll(rd);
@@ -215,6 +204,21 @@ public class CDXSearchService {
                 }
             }
         }
+    }
+
+    /**
+     * Opens a connection to the CDX server. Extracted as its own method so tests can stub it out via
+     * {@code Mockito.spy(...)} instead of hitting the network.
+     */
+    URLConnection openCdxConnection(String strurl) throws IOException {
+        URL url = new URL(strurl);
+        URLConnection con = strurl.startsWith("https")
+                ? (HttpsURLConnection) url.openConnection()
+                : url.openConnection();
+        con.setConnectTimeout(timeoutConn);
+        // set this to a globaltimeout equal to all services
+        con.setReadTimeout(timeoutreadConn);
+        return con;
     }
 
     /**

--- a/page-search-api/src/main/java/pt/arquivo/services/solr/SolrSearchService.java
+++ b/page-search-api/src/main/java/pt/arquivo/services/solr/SolrSearchService.java
@@ -96,7 +96,7 @@ public class SolrSearchService implements SearchService {
      * @param dedupField
      * @return
      */
-    private String sanitizeDedupField(String dedupField){
+    String sanitizeDedupField(String dedupField){
         if (dedupField == null) { 
             dedupField = "";
         }
@@ -142,7 +142,7 @@ public class SolrSearchService implements SearchService {
      * @param searchQuery
      * @return
      */
-    private SolrQuery convertSearchQuery(SearchQuery searchQuery) {
+    SolrQuery convertSearchQuery(SearchQuery searchQuery) {
         SolrQuery solrQuery = new SolrQuery();
 
         if(searchQuery.getQueryTerms() == null){
@@ -377,7 +377,7 @@ public class SolrSearchService implements SearchService {
     /**
      * Escapes special symbols, but not all of them to allow for "" (exact match) and - (excluding) searches
      */
-    private String sanitizeQuery(String query, SolrQuery solrQuery){
+    String sanitizeQuery(String query, SolrQuery solrQuery){
         
         Pattern exactMatchPattern = Pattern.compile("(^|.*?\\s)\"([^\"]*)\"(\\s.*|$)");
         String line = query;
@@ -501,7 +501,7 @@ public class SolrSearchService implements SearchService {
      * @param tu
      * @return String
      */
-    private String timestampSurtToCollection(String tu) {
+    String timestampSurtToCollection(String tu) {
         return tu.substring(0, tu.indexOf("/"));
     }
 
@@ -511,7 +511,7 @@ public class SolrSearchService implements SearchService {
      * @param tu
      * @return String
      */
-    private String timestampSurtToTimestamp(String tu) {
+    String timestampSurtToTimestamp(String tu) {
         String r = tu.substring(tu.indexOf("/") + 1);
         return r.substring(0, r.indexOf("/"));
     }
@@ -522,7 +522,7 @@ public class SolrSearchService implements SearchService {
      * @param tu
      * @return String
      */
-    private String timestampSurtToSurt(String tu) {
+    String timestampSurtToSurt(String tu) {
         String r = tu.substring(tu.indexOf("/") + 1);
         return r.substring(r.indexOf("/") + 1);
     }
@@ -533,7 +533,7 @@ public class SolrSearchService implements SearchService {
      * siteSearch or collection doesn't match collection search
      *
      */
-    private List<Object> filterUrlTimestamps(List <Object> urlstimestamps, Long to, Long from, String[] siteSearchSurts, String[] collectionSearch){
+    List<Object> filterUrlTimestamps(List <Object> urlstimestamps, Long to, Long from, String[] siteSearchSurts, String[] collectionSearch){
                 urlstimestamps = urlstimestamps.stream()
                         .filter(u -> ((String) u).indexOf("/") >= 0)
                         .collect(Collectors.toList());
@@ -572,7 +572,7 @@ public class SolrSearchService implements SearchService {
      * Given a list of strings in the format collection/timestamp/surt (as returned by the Solr field urlTimestamp), will
      * return the one with the oldest timestamp
      */
-    private String getOldestUrlTimestamp(List <Object> urlstimestamps){
+    String getOldestUrlTimestamp(List <Object> urlstimestamps){
         String oldestTimestamp = null;
         String oldestUrlTimestamp = null;
         Iterator<Object> it = (Iterator<Object>) urlstimestamps.iterator();
@@ -739,7 +739,7 @@ public class SolrSearchService implements SearchService {
      * @param searchQuery
      * @return
      */
-    private String parseSuggestedQuery(QueryResponse queryResponse, SearchQuery searchQuery) {
+    String parseSuggestedQuery(QueryResponse queryResponse, SearchQuery searchQuery) {
         SpellCheckResponse spellCheckResponse = queryResponse.getSpellCheckResponse();
         if (spellCheckResponse == null) {
             return null;

--- a/page-search-api/src/main/java/pt/arquivo/services/solr/SolrSearchService.java
+++ b/page-search-api/src/main/java/pt/arquivo/services/solr/SolrSearchService.java
@@ -41,7 +41,7 @@ public class SolrSearchService implements SearchService {
     private static final Logger LOG = LoggerFactory.getLogger(SolrSearchService.class);
 
     // TODO should upgrade this for the SolrCloudClient
-    private HttpSolrClient solrClient;
+    HttpSolrClient solrClient;
 
     @Value("${searchpages.api.startdate:19960101000000}")
     private String startDate;

--- a/page-search-api/src/test/java/pt/arquivo/api/SERPLoggingTest.java
+++ b/page-search-api/src/test/java/pt/arquivo/api/SERPLoggingTest.java
@@ -1,0 +1,33 @@
+package pt.arquivo.api;
+
+import org.junit.Test;
+import pt.arquivo.services.SearchQueryImpl;
+import pt.arquivo.services.SearchResultNutchImpl;
+
+import java.util.ArrayList;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SERPLoggingTest {
+
+    @Test
+    public void logResult_buildsTabDelimitedLineWithQueryAndResultIds() {
+        SearchQueryImpl searchQuery = new SearchQueryImpl("sapo");
+
+        SearchResultNutchImpl result = new SearchResultNutchImpl();
+        result.setTimeStamp("20190101010101");
+        result.setOriginalURL("http://example.com");
+
+        ArrayList<pt.arquivo.services.SearchResult> responseItems = new ArrayList<>();
+        responseItems.add(result);
+        PageSearchResponse pageSearchResponse = new PageSearchResponse();
+        pageSearchResponse.setResponseItems(responseItems);
+
+        String log = SERPLogging.logResult(123L, "127.0.0.1", "curl/7.0", "/textsearch?q=sapo",
+                pageSearchResponse, searchQuery);
+
+        assertThat(log).startsWith("127.0.0.1\tcurl/7.0\t/textsearch?q=sapo\t123 ms\tsearch_parameters: ");
+        assertThat(log).contains("\"q\":\"sapo\"");
+        assertThat(log).contains("\tsearch_results: [\"20190101010101/http://example.com\"]");
+    }
+}

--- a/page-search-api/src/test/java/pt/arquivo/api/exceptions/ApiExceptionHandlerTest.java
+++ b/page-search-api/src/test/java/pt/arquivo/api/exceptions/ApiExceptionHandlerTest.java
@@ -1,0 +1,35 @@
+package pt.arquivo.api.exceptions;
+
+import org.junit.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ApiExceptionHandlerTest {
+
+    private final ApiExceptionHandler handler = new ApiExceptionHandler();
+
+    @Test
+    public void handleApiRequestException_returnsBadRequestWithMessage() {
+        ResponseEntity<Object> response = handler.handleApiRequestException(new ApiRequestException("bad input"));
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        ApiException body = (ApiException) response.getBody();
+        assertThat(body.getMessage()).isEqualTo("bad input");
+        assertThat(body.getHttpStatus()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+        assertThat(body.getTimestamp()).isNotNull();
+    }
+
+    @Test
+    public void handleApiNotFoundResourceException_returnsNotFoundWithMessage() {
+        ResponseEntity<Object> response = handler
+                .handleApiNotFoundResourceException(new ApiNotFoundResourceException("missing resource"));
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+        ApiException body = (ApiException) response.getBody();
+        assertThat(body.getMessage()).isEqualTo("missing resource");
+        assertThat(body.getHttpStatus()).isEqualTo(HttpStatus.NOT_FOUND.value());
+        assertThat(body.getTimestamp()).isNotNull();
+    }
+}

--- a/page-search-api/src/test/java/pt/arquivo/services/SearchResultSerializerTest.java
+++ b/page-search-api/src/test/java/pt/arquivo/services/SearchResultSerializerTest.java
@@ -1,0 +1,110 @@
+package pt.arquivo.services;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.solr.client.solrj.impl.HttpSolrClient;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.io.StringWriter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SearchResultSerializerTest {
+
+    private SearchResultSerializer serializer;
+    private SearchResultSolrImpl result;
+    private HttpSolrClient solrClient;
+
+    @Before
+    public void setUp() {
+        serializer = new SearchResultSerializer();
+        result = new SearchResultSolrImpl();
+        result.setTitle("Example Title");
+        result.setOriginalURL("http://example.com");
+        result.setId("doc123");
+        solrClient = new HttpSolrClient.Builder("http://localhost:1/solr").build();
+        result.setSolrClient(solrClient);
+    }
+
+    @After
+    public void tearDown() throws IOException {
+        solrClient.close();
+    }
+
+    private JsonNode serialize() throws IOException {
+        ObjectMapper mapper = new ObjectMapper();
+        StringWriter writer = new StringWriter();
+        // Use an ObjectMapper-backed generator (not a bare JsonFactory) so it can serialize
+        // any synthetic/instrumentation fields the JVM may inject (e.g. coverage tooling),
+        // since the class under test iterates over ALL declared fields via reflection.
+        JsonGenerator generator = mapper.getFactory().createGenerator(writer);
+        serializer.serialize(result, generator, null);
+        generator.close();
+        return mapper.readTree(writer.toString());
+    }
+
+    @Test
+    public void defaultMode_neverLeaksInternalFields() throws IOException {
+        serializer.showIds = false;
+        JsonNode node = serialize();
+
+        assertThat(node.has("solrClient")).isFalse();
+        assertThat(node.has("LOG")).isFalse();
+        assertThat(node.has("fields")).isFalse();
+        assertThat(node.get("title").asText()).isEqualTo("Example Title");
+        assertThat(node.get("originalURL").asText()).isEqualTo("http://example.com");
+    }
+
+    @Test
+    public void defaultMode_hidesIdWhenShowIdsIsFalse() throws IOException {
+        serializer.showIds = false;
+        JsonNode node = serialize();
+        assertThat(node.has("id")).isFalse();
+    }
+
+    @Test
+    public void defaultMode_showsIdWhenShowIdsIsTrue() throws IOException {
+        serializer.showIds = true;
+        JsonNode node = serialize();
+        assertThat(node.get("id").asText()).isEqualTo("doc123");
+    }
+
+    @Test
+    public void defaultMode_omitsNullFields() throws IOException {
+        serializer.showIds = false;
+        result.setDigest(null);
+        JsonNode node = serialize();
+        assertThat(node.has("digest")).isFalse();
+    }
+
+    @Test
+    public void whitelistMode_onlyIncludesRequestedFields() throws IOException {
+        serializer.showIds = false;
+        result.setFields(new String[] { "title" });
+        JsonNode node = serialize();
+
+        assertThat(node.get("title").asText()).isEqualTo("Example Title");
+        assertThat(node.has("originalURL")).isFalse();
+    }
+
+    @Test
+    public void whitelistMode_fieldMatchingIsCaseInsensitive() throws IOException {
+        serializer.showIds = false;
+        result.setFields(new String[] { "TITLE" });
+        JsonNode node = serialize();
+        assertThat(node.get("title").asText()).isEqualTo("Example Title");
+    }
+
+    @Test
+    public void whitelistMode_idIsNotGatedByShowIds() throws IOException {
+        // Unlike default mode, requesting "id" explicitly via the fields whitelist bypasses the showIds gate
+        serializer.showIds = false;
+        result.setFields(new String[] { "id" });
+        JsonNode node = serialize();
+        assertThat(node.get("id").asText()).isEqualTo("doc123");
+    }
+}

--- a/page-search-api/src/test/java/pt/arquivo/services/SearchResultSolrImplTest.java
+++ b/page-search-api/src/test/java/pt/arquivo/services/SearchResultSolrImplTest.java
@@ -1,0 +1,17 @@
+package pt.arquivo.services;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SearchResultSolrImplTest {
+
+    @Test
+    public void getSearchResultId_combinesTstampAndOriginalUrl() {
+        SearchResultSolrImpl result = new SearchResultSolrImpl();
+        result.setTimeStamp("20190101010101");
+        result.setOriginalURL("http://example.com");
+
+        assertThat(result.getSearchResultId()).isEqualTo("20190101010101/http://example.com");
+    }
+}

--- a/page-search-api/src/test/java/pt/arquivo/services/cdx/CDXSearchServiceTest.java
+++ b/page-search-api/src/test/java/pt/arquivo/services/cdx/CDXSearchServiceTest.java
@@ -3,9 +3,21 @@ package pt.arquivo.services.cdx;
 import org.junit.Before;
 import org.junit.Test;
 import pt.arquivo.services.SearchResultNutchImpl;
+import pt.arquivo.services.SearchResults;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.net.URLConnection;
+import java.nio.charset.StandardCharsets;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
 
 public class CDXSearchServiceTest {
 
@@ -105,5 +117,45 @@ public class CDXSearchServiceTest {
 
         assertThat(result.getLinkToExtractedText()).isEqualTo("http://extractedtext.example.com?m="
                 + "http%3A%2F%2Fexample.com%2F201901010101203401");
+    }
+
+    private static URLConnection connectionReturning(String body) throws IOException {
+        URLConnection connection = mock(URLConnection.class);
+        when(connection.getInputStream()).thenReturn(
+                new ByteArrayInputStream(body.getBytes(StandardCharsets.UTF_8)));
+        return connection;
+    }
+
+    @Test
+    public void getResults_happyPath_mapsCdxJsonToSearchResults() throws Exception {
+        String cdxJson = "{\"url\":\"http://example.com\",\"timestamp\":\"20190101010101\","
+                + "\"digest\":\"DIGEST123\",\"mime\":\"text/html\",\"status\":\"200\","
+                + "\"filename\":\"some-file.warc.gz\",\"length\":\"80\",\"offset\":\"1234\","
+                + "\"collection\":\"COLLECTION1\"}\n";
+
+        CDXSearchService spy = spy(cdxSearchService);
+        doReturn(connectionReturning(cdxJson)).when(spy).openCdxConnection(anyString());
+
+        SearchResults results = spy.getResults("http://example.com", null, null, 10, 0);
+
+        assertThat(results.getEstimatedNumberResults()).isEqualTo(1);
+        assertThat(results.getResults()).hasSize(1);
+        SearchResultNutchImpl result = (SearchResultNutchImpl) results.getResults().get(0);
+        assertThat(result.getOriginalURL()).isEqualTo("http://example.com");
+        assertThat(result.getTitle()).isEqualTo("http://example.com");
+        assertThat(result.getTstamp()).isEqualTo("20190101010101");
+        assertThat(result.getCollection()).isEqualTo("COLLECTION1");
+        assertThat(result.getLinkToArchive()).isEqualTo("http://wayback.example.com/wayback/20190101010101/http://example.com");
+    }
+
+    @Test
+    public void getResults_connectionThrows_returnsZeroResults() throws Exception {
+        CDXSearchService spy = spy(cdxSearchService);
+        doThrow(new IOException("boom")).when(spy).openCdxConnection(anyString());
+
+        SearchResults results = spy.getResults("http://example.com", null, null, 10, 0);
+
+        assertThat(results.getEstimatedNumberResults()).isEqualTo(0);
+        assertThat(results.getResults()).isNull();
     }
 }

--- a/page-search-api/src/test/java/pt/arquivo/services/cdx/CDXSearchServiceTest.java
+++ b/page-search-api/src/test/java/pt/arquivo/services/cdx/CDXSearchServiceTest.java
@@ -1,0 +1,109 @@
+package pt.arquivo.services.cdx;
+
+import org.junit.Before;
+import org.junit.Test;
+import pt.arquivo.services.SearchResultNutchImpl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class CDXSearchServiceTest {
+
+    private CDXSearchService cdxSearchService;
+
+    @Before
+    public void setUp() {
+        cdxSearchService = new CDXSearchService();
+        cdxSearchService.waybackCdxEndpoint = "http://wayback.example.com/cdx";
+        cdxSearchService.waybackServiceEndpoint = "http://wayback.example.com/wayback";
+        cdxSearchService.waybackNoFrameServiceEndpoint = "http://wayback.example.com/noFrame";
+        cdxSearchService.screenshotServiceEndpoint = "http://screenshot.example.com";
+        cdxSearchService.textSearchServiceEndpoint = "http://textsearch.example.com";
+        cdxSearchService.extractedTextServiceEndpoint = "http://extractedtext.example.com";
+    }
+
+    @Test
+    public void getSearchResultNutch_mapsAllFields() {
+        ItemCDX itemCDX = new ItemCDX("http://example.com", "201901010101203401", "DIGEST123",
+                "text/html", "200", "some-file.warc.gz", "80", "1234", "COLLECTION1");
+
+        SearchResultNutchImpl result = CDXSearchService.getSearchResultNutch(itemCDX);
+
+        assertThat(result.getFileName()).isEqualTo("some-file.warc.gz");
+        assertThat(result.getOffset()).isEqualTo(1234L);
+        assertThat(result.getContentLength()).isEqualTo(80L);
+        assertThat(result.getDigest()).isEqualTo("DIGEST123");
+        assertThat(result.getMimeType()).isEqualTo("text/html");
+        assertThat(result.getTstamp()).isEqualTo("201901010101203401");
+        assertThat(result.getOriginalURL()).isEqualTo("http://example.com");
+        assertThat(result.getStatusCode()).isEqualTo(200);
+        assertThat(result.getCollection()).isEqualTo("COLLECTION1");
+    }
+
+    @Test
+    public void getSearchResultNutch_toleratesNullLengthAndStatus() {
+        ItemCDX itemCDX = new ItemCDX("http://example.com", "201901010101203401", "DIGEST123",
+                "text/html", null, "some-file.warc.gz", null, "1234", "COLLECTION1");
+
+        SearchResultNutchImpl result = CDXSearchService.getSearchResultNutch(itemCDX);
+
+        assertThat(result.getContentLength()).isEqualTo(0L);
+        assertThat(result.getStatusCode()).isNull();
+    }
+
+    @Test
+    public void getSearchResultNutch_throwsOnMalformedOffset() {
+        // Documents current fragile behavior: a malformed CDX "offset" field blows up the whole mapping
+        ItemCDX itemCDX = new ItemCDX("http://example.com", "201901010101203401", "DIGEST123",
+                "text/html", "200", "some-file.warc.gz", "80", "not-a-number", "COLLECTION1");
+
+        assertThatThrownBy(() -> CDXSearchService.getSearchResultNutch(itemCDX))
+                .isInstanceOf(NumberFormatException.class);
+    }
+
+    @Test
+    public void generateCdxQuery_buildsUrlWithEncodedQueryAndFromTo() {
+        String query = cdxSearchService.generateCdxQuery("http://example.com/a b", "20190101000000", "20200101000000");
+
+        assertThat(query).isEqualTo("http://wayback.example.com/cdx?url=http%3A%2F%2Fexample.com%2Fa+b"
+                + "&output=json&from=20190101000000&to=20200101000000&reverse=true");
+    }
+
+    @Test
+    public void generateCdxQuery_treatsNullFromAndToAsEmpty() {
+        String query = cdxSearchService.generateCdxQuery("http://example.com", null, null);
+
+        assertThat(query).isEqualTo("http://wayback.example.com/cdx?url=http%3A%2F%2Fexample.com"
+                + "&output=json&from=&to=&reverse=true");
+    }
+
+    @Test
+    public void populateEndpointsLinks_withoutTextMatch_doesNotSetExtractedTextLink() throws Exception {
+        SearchResultNutchImpl result = new SearchResultNutchImpl();
+        result.setTimeStamp("201901010101203401");
+        result.setOriginalURL("http://example.com");
+
+        cdxSearchService.populateEndpointsLinks(result, false);
+
+        assertThat(result.getLinkToArchive()).isEqualTo("http://wayback.example.com/wayback/201901010101203401/http://example.com");
+        assertThat(result.getLinkToNoFrame()).isEqualTo("http://wayback.example.com/noFrame/201901010101203401/http://example.com");
+        assertThat(result.getLinkToScreenshot()).isEqualTo("http://screenshot.example.com?url="
+                + "http%3A%2F%2Fwayback.example.com%2FnoFrame%2F201901010101203401%2Fhttp%3A%2F%2Fexample.com");
+        assertThat(result.getLinkToOriginalFile()).isEqualTo("http://wayback.example.com/noFrame/201901010101203401id_/http://example.com");
+        assertThat(result.getLinkToMetadata()).isEqualTo("http://textsearch.example.com?metadata="
+                + "http%3A%2F%2Fexample.com%2F201901010101203401");
+        assertThat(result.getLinkToExtractedText()).isNull();
+    }
+
+    @Test
+    public void populateEndpointsLinks_withTextMatch_setsExtractedTextLink() throws Exception {
+        SearchResultNutchImpl result = new SearchResultNutchImpl();
+        result.setTimeStamp("201901010101203401");
+        result.setOriginalURL("http://example.com");
+
+        cdxSearchService.populateEndpointsLinks(result, true);
+
+        assertThat(result.getLinkToExtractedText()).isEqualTo("http://extractedtext.example.com?m="
+                + "http%3A%2F%2Fexample.com%2F201901010101203401");
+    }
+}

--- a/page-search-api/src/test/java/pt/arquivo/services/solr/SolrSearchServiceTest.java
+++ b/page-search-api/src/test/java/pt/arquivo/services/solr/SolrSearchServiceTest.java
@@ -1,20 +1,33 @@
 package pt.arquivo.services.solr;
 
 import org.apache.solr.client.solrj.SolrQuery;
+import org.apache.solr.client.solrj.SolrServerException;
+import org.apache.solr.client.solrj.impl.HttpSolrClient;
 import org.apache.solr.client.solrj.response.QueryResponse;
 import org.apache.solr.client.solrj.response.SpellCheckResponse;
 import org.apache.solr.client.solrj.util.ClientUtils;
+import org.apache.solr.common.SolrDocument;
+import org.apache.solr.common.SolrDocumentList;
 import org.apache.solr.common.util.NamedList;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
 import pt.arquivo.services.SearchQuery;
 import pt.arquivo.services.SearchQueryImpl;
+import pt.arquivo.services.SearchResultSolrImpl;
+import pt.arquivo.services.SearchResults;
+import pt.arquivo.services.SearchServiceConfiguration;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class SolrSearchServiceTest {
 
@@ -22,7 +35,16 @@ public class SolrSearchServiceTest {
 
     @Before
     public void setUp() {
-        service = new SolrSearchService();
+        SearchServiceConfiguration configuration = new SearchServiceConfiguration();
+        configuration.setStartDate("19960101000000");
+        configuration.setServiceName("http://localhost:8081");
+        configuration.setScreenshotServiceEndpoint("http://screenshot.example.com");
+        configuration.setWaybackServiceEndpoint("http://wayback.example.com/wayback");
+        configuration.setWaybackNoFrameServiceEndpoint("http://wayback.example.com/noFrame");
+        configuration.setExtractedTextServiceEndpoint("http://extractedtext.example.com");
+        configuration.setBaseSolrUrl("http://solr.example.com/solr/searchpages");
+        configuration.setTextSearchServiceEndpoint("http://textsearch.example.com");
+        service = new SolrSearchService(configuration);
     }
 
     @Test
@@ -230,5 +252,151 @@ public class SolrSearchServiceTest {
         SearchQueryImpl searchQuery = new SearchQueryImpl("\"origanal query\"");
         QueryResponse queryResponse = queryResponseWithCollation("\"original query\"");
         assertThat(service.parseSuggestedQuery(queryResponse, searchQuery)).isEqualTo("\"original query\"");
+    }
+
+    private static SolrDocument docWithUrlTimestamp(String id, String urlTimestamp) {
+        SolrDocument doc = new SolrDocument();
+        doc.addField("id", id);
+        doc.addField("urlTimestamp", urlTimestamp);
+        return doc;
+    }
+
+    private static QueryResponse queryResponseWithResults(SolrDocument... docs) {
+        SolrDocumentList docList = new SolrDocumentList();
+        docList.addAll(Arrays.asList(docs));
+        docList.setNumFound(docs.length);
+
+        NamedList<Object> response = new NamedList<>();
+        response.add("response", docList);
+        // Highlighting is on by default in Solr whenever snippets are requested (see convertSearchQuery),
+        // so a real response always carries a "highlighting" key, even if empty for every doc.
+        response.add("highlighting", new NamedList<>());
+
+        QueryResponse queryResponse = new QueryResponse();
+        queryResponse.setResponse(response);
+        return queryResponse;
+    }
+
+    private static QueryResponse queryResponseWithHighlighting(SolrDocument doc, String fieldName, String snippet) {
+        NamedList<List<String>> docHighlight = new NamedList<>();
+        docHighlight.add(fieldName, Arrays.asList(snippet));
+        NamedList<Object> highlighting = new NamedList<>();
+        highlighting.add((String) doc.getFieldValue("id"), docHighlight);
+
+        SolrDocumentList docList = new SolrDocumentList();
+        docList.add(doc);
+        docList.setNumFound(1);
+
+        NamedList<Object> response = new NamedList<>();
+        response.add("response", docList);
+        response.add("highlighting", highlighting);
+
+        QueryResponse queryResponse = new QueryResponse();
+        queryResponse.setResponse(response);
+        return queryResponse;
+    }
+
+    @Test
+    public void query_happyPath_mapsSolrDocumentToSearchResult() throws Exception {
+        SolrDocument doc = docWithUrlTimestamp("doc-1", "COLLECTION1/20190101010101/(com,example,)/path");
+        QueryResponse queryResponse = queryResponseWithResults(doc);
+
+        HttpSolrClient solrClient = mock(HttpSolrClient.class);
+        when(solrClient.query(any(SolrQuery.class))).thenReturn(queryResponse);
+        service.solrClient = solrClient;
+
+        SearchQueryImpl searchQuery = new SearchQueryImpl("sapo");
+        SearchResults results = service.query(searchQuery);
+
+        assertThat(results.getEstimatedNumberResults()).isEqualTo(1);
+        assertThat(results.getNumberResults()).isEqualTo(1);
+        assertThat(results.isLastPageResults()).isTrue();
+        assertThat(results.getResults()).hasSize(1);
+        assertThat(results.getResults().get(0).getId()).isEqualTo("doc-1");
+        assertThat(results.getResults().get(0).getCollection()).isEqualTo("COLLECTION1");
+        assertThat(results.getResults().get(0).getTstamp()).isEqualTo("20190101010101");
+    }
+
+    @Test
+    public void query_solrServerException_returnsEmptyFallbackResults() throws Exception {
+        HttpSolrClient solrClient = mock(HttpSolrClient.class);
+        when(solrClient.query(any(SolrQuery.class))).thenThrow(new SolrServerException("boom"));
+        service.solrClient = solrClient;
+
+        SearchResults results = service.query(new SearchQueryImpl("sapo"));
+
+        assertThat(results.getEstimatedNumberResults()).isEqualTo(0);
+        assertThat(results.getNumberResults()).isEqualTo(0);
+        assertThat(results.isLastPageResults()).isFalse();
+        assertThat(results.getResults()).isNull();
+    }
+
+    @Test
+    public void getHighlightedText_usesHighlightSnippetWhenPresent() {
+        SolrDocument doc = docWithUrlTimestamp("doc-1", "COLLECTION1/20190101010101/(com,example,)/path");
+        QueryResponse queryResponse = queryResponseWithHighlighting(doc, "content", "hi <em>there</em>");
+
+        String highlighted = service.getHighlightedText(queryResponse, "content", "doc-1");
+
+        assertThat(highlighted).isEqualTo("hi <em>there</em><span class=\"ellipsis\"> ... </span>");
+    }
+
+    @Test
+    public void getHighlightedText_fallsBackToContentFieldWhenNoHighlight() throws Exception {
+        SolrDocument doc = docWithUrlTimestamp("doc-1", "COLLECTION1/20190101010101/(com,example,)/path");
+        QueryResponse queryResponse = queryResponseWithResults(doc);
+
+        SolrDocument contentDoc = new SolrDocument();
+        contentDoc.addField("content", "short content");
+        QueryResponse contentResponse = queryResponseWithResults(contentDoc);
+
+        HttpSolrClient solrClient = mock(HttpSolrClient.class);
+        when(solrClient.query(any(SolrQuery.class))).thenReturn(contentResponse);
+        service.solrClient = solrClient;
+
+        String highlighted = service.getHighlightedText(queryResponse, "content", "doc-1");
+
+        assertThat(highlighted).isEqualTo("short content");
+    }
+
+    @Test
+    public void getHighlightedText_truncatesLongContentFallbackWithEllipsis() throws Exception {
+        SolrDocument doc = docWithUrlTimestamp("doc-1", "COLLECTION1/20190101010101/(com,example,)/path");
+        QueryResponse queryResponse = queryResponseWithResults(doc);
+
+        String longContent = String.join("", java.util.Collections.nCopies(600, "a"));
+        SolrDocument contentDoc = new SolrDocument();
+        contentDoc.addField("content", longContent);
+        QueryResponse contentResponse = queryResponseWithResults(contentDoc);
+
+        HttpSolrClient solrClient = mock(HttpSolrClient.class);
+        when(solrClient.query(any(SolrQuery.class))).thenReturn(contentResponse);
+        service.solrClient = solrClient;
+
+        String highlighted = service.getHighlightedText(queryResponse, "content", "doc-1");
+
+        assertThat(highlighted).isEqualTo(longContent.substring(0, 500) + "<span class=\"ellipsis\"> ... </span>");
+    }
+
+    @Test
+    public void query_urlSearch_true_queriesByUrlTimestampAndExcludesSnippet() throws Exception {
+        SolrDocument doc = docWithUrlTimestamp("doc-1", "COLLECTION1/20190101000000/(com,example,)/path");
+        QueryResponse queryResponse = queryResponseWithResults(doc);
+
+        HttpSolrClient solrClient = mock(HttpSolrClient.class);
+        when(solrClient.query(any(SolrQuery.class))).thenReturn(queryResponse);
+        service.solrClient = solrClient;
+
+        SearchQueryImpl searchQuery = new SearchQueryImpl("http://example.com");
+        searchQuery.setFrom("20190101000000");
+
+        SearchResults results = service.query(searchQuery, true);
+
+        ArgumentCaptor<SolrQuery> solrQueryCaptor = ArgumentCaptor.forClass(SolrQuery.class);
+        verify(solrClient).query(solrQueryCaptor.capture());
+        assertThat(solrQueryCaptor.getValue().getQuery()).startsWith("urlTimestamp:*/20190101000000/");
+
+        assertThat(results.getResults()).hasSize(1);
+        assertThat(((SearchResultSolrImpl) results.getResults().get(0)).getSnippet()).isNull();
     }
 }

--- a/page-search-api/src/test/java/pt/arquivo/services/solr/SolrSearchServiceTest.java
+++ b/page-search-api/src/test/java/pt/arquivo/services/solr/SolrSearchServiceTest.java
@@ -1,11 +1,29 @@
 package pt.arquivo.services.solr;
 
+import org.apache.solr.client.solrj.SolrQuery;
+import org.apache.solr.client.solrj.response.QueryResponse;
+import org.apache.solr.client.solrj.response.SpellCheckResponse;
+import org.apache.solr.client.solrj.util.ClientUtils;
+import org.apache.solr.common.util.NamedList;
+import org.junit.Before;
 import org.junit.Test;
 import pt.arquivo.services.SearchQuery;
 import pt.arquivo.services.SearchQueryImpl;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class SolrSearchServiceTest {
+
+    private SolrSearchService service;
+
+    @Before
+    public void setUp() {
+        service = new SolrSearchService();
+    }
 
     @Test
     public void isLastPage() {
@@ -14,5 +32,203 @@ public class SolrSearchServiceTest {
         searchQuery.setMaxItems(10);
         assertThat(SolrSearchService.isLastPage(20, searchQuery)).isTrue();
         assertThat(SolrSearchService.isLastPage(21, searchQuery)).isFalse();
+    }
+
+    @Test
+    public void sanitizeDedupField_defaultsToTitleStringForNullOrInvalid() {
+        assertThat(service.sanitizeDedupField(null)).isEqualTo("titleString");
+        assertThat(service.sanitizeDedupField("")).isEqualTo("titleString");
+        assertThat(service.sanitizeDedupField("not-a-real-field")).isEqualTo("titleString");
+        // "title" is a valid dedup field name but is explicitly redirected to "titleString" too
+        assertThat(service.sanitizeDedupField("title")).isEqualTo("titleString");
+    }
+
+    @Test
+    public void sanitizeDedupField_mapsSiteAndSurtToSurtOldest() {
+        assertThat(service.sanitizeDedupField("site")).isEqualTo("surtOldest");
+        assertThat(service.sanitizeDedupField("surt")).isEqualTo("surtOldest");
+        // matching is case-insensitive
+        assertThat(service.sanitizeDedupField("SITE")).isEqualTo("surtOldest");
+    }
+
+    @Test
+    public void sanitizeDedupField_mapsMimetypeToType() {
+        assertThat(service.sanitizeDedupField("mimetype")).isEqualTo("type");
+    }
+
+    @Test
+    public void sanitizeDedupField_passesThroughOtherValidFieldsUnchanged() {
+        assertThat(service.sanitizeDedupField("type")).isEqualTo("type");
+        assertThat(service.sanitizeDedupField("collection")).isEqualTo("collection");
+    }
+
+    @Test
+    public void sanitizeQuery_preservesExactMatchQuotedPhrase() {
+        SolrQuery solrQuery = new SolrQuery();
+        String result = service.sanitizeQuery("\"hello world\"", solrQuery);
+        // the phrase inside the quotes is still escaped like any other term (e.g. the space becomes "\ ")
+        assertThat(result).isEqualTo("\"" + ClientUtils.escapeQueryChars("hello world") + "\"");
+        assertThat(solrQuery.getFilterQueries()).isNull();
+    }
+
+    @Test
+    public void sanitizeQuery_extractsExcludeTermsAsFilterQueries() {
+        SolrQuery solrQuery = new SolrQuery();
+        String result = service.sanitizeQuery("hello -world", solrQuery);
+        assertThat(result).isEqualTo(ClientUtils.escapeQueryChars("hello "));
+        assertThat(solrQuery.getFilterQueries()).containsExactlyInAnyOrder("-content:world", "-title:world");
+    }
+
+    @Test
+    public void sanitizeQuery_escapesSpecialCharacters() {
+        SolrQuery solrQuery = new SolrQuery();
+        String result = service.sanitizeQuery("hello (world)", solrQuery);
+        assertThat(result).isEqualTo(ClientUtils.escapeQueryChars("hello (world)"));
+    }
+
+    @Test
+    public void convertSearchQuery_defaultsToMatchAllWhenNoQueryTerms() {
+        SearchQueryImpl searchQuery = new SearchQueryImpl(null);
+        SolrQuery solrQuery = service.convertSearchQuery(searchQuery);
+        assertThat(solrQuery.getQuery()).isEqualTo("*:*");
+    }
+
+    @Test
+    public void convertSearchQuery_mapsPdfTypeToApplicationPdfMimetype() {
+        SearchQueryImpl searchQuery = new SearchQueryImpl("sapo");
+        searchQuery.setType(new String[] { "pdf" });
+        SolrQuery solrQuery = service.convertSearchQuery(searchQuery);
+        assertThat(solrQuery.getFilterQueries())
+                .contains("type:" + ClientUtils.escapeQueryChars("application/pdf"));
+    }
+
+    @Test
+    public void convertSearchQuery_mapsOfficeAliasTypeToTwoMimetypesWithOr() {
+        SearchQueryImpl searchQuery = new SearchQueryImpl("sapo");
+        searchQuery.setType(new String[] { "xls" });
+        SolrQuery solrQuery = service.convertSearchQuery(searchQuery);
+        String expected = "type:" + ClientUtils.escapeQueryChars("application/vnd.ms-excel")
+                + " OR type:" + ClientUtils.escapeQueryChars("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
+        assertThat(solrQuery.getFilterQueries()).contains(expected);
+    }
+
+    @Test
+    public void convertSearchQuery_unknownTypeFallsBackToWildcardMatch() {
+        SearchQueryImpl searchQuery = new SearchQueryImpl("sapo");
+        searchQuery.setType(new String[] { "zzz" });
+        SolrQuery solrQuery = service.convertSearchQuery(searchQuery);
+        assertThat(solrQuery.getFilterQueries())
+                .contains("type:*" + ClientUtils.escapeQueryChars("zzz") + "*");
+    }
+
+    @Test
+    public void convertSearchQuery_explicitMimetypeWithSlashIsUsedAsIs() {
+        SearchQueryImpl searchQuery = new SearchQueryImpl("sapo");
+        searchQuery.setType(new String[] { "application/zip" });
+        SolrQuery solrQuery = service.convertSearchQuery(searchQuery);
+        assertThat(solrQuery.getFilterQueries())
+                .contains("type:" + ClientUtils.escapeQueryChars("application/zip"));
+    }
+
+    @Test
+    public void timestampSurtTo_extractsCollectionTimestampAndSurt() {
+        String urlTimestamp = "COLLECTION1/20190101000000/(com,example,)/path";
+        assertThat(service.timestampSurtToCollection(urlTimestamp)).isEqualTo("COLLECTION1");
+        assertThat(service.timestampSurtToTimestamp(urlTimestamp)).isEqualTo("20190101000000");
+        assertThat(service.timestampSurtToSurt(urlTimestamp)).isEqualTo("(com,example,)/path");
+    }
+
+    @Test
+    public void filterUrlTimestamps_dropsEntriesWithoutSlash() {
+        List<Object> urlstimestamps = new ArrayList<>(Arrays.asList("malformed-entry-no-slash"));
+        List<Object> result = service.filterUrlTimestamps(urlstimestamps, null, null, null, null);
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    public void filterUrlTimestamps_filtersBySiteSearchSurtPrefix() {
+        List<Object> urlstimestamps = new ArrayList<>(Arrays.asList(
+                "COLLECTION1/20190101000000/(com,example,)/path1",
+                "COLLECTION1/20190101000000/(com,other,)/path2"));
+        List<Object> result = service.filterUrlTimestamps(urlstimestamps, null, null,
+                new String[] { "(com,example,)" }, null);
+        assertThat(result).containsExactly("COLLECTION1/20190101000000/(com,example,)/path1");
+    }
+
+    @Test
+    public void filterUrlTimestamps_filtersByTimeRange() {
+        List<Object> urlstimestamps = new ArrayList<>(Arrays.asList(
+                "COLLECTION1/20180101000000/(com,example,)/path1",
+                "COLLECTION1/20190101000000/(com,example,)/path2",
+                "COLLECTION1/20200101000000/(com,example,)/path3"));
+        List<Object> result = service.filterUrlTimestamps(urlstimestamps, 20191231000000L, 20190101000000L, null, null);
+        assertThat(result).containsExactly("COLLECTION1/20190101000000/(com,example,)/path2");
+    }
+
+    @Test
+    public void filterUrlTimestamps_filtersByCollection() {
+        List<Object> urlstimestamps = new ArrayList<>(Arrays.asList(
+                "COLLECTION1/20190101000000/(com,example,)/path1",
+                "COLLECTION2/20190101000000/(com,example,)/path2"));
+        List<Object> result = service.filterUrlTimestamps(urlstimestamps, null, null, null,
+                new String[] { "COLLECTION1" });
+        assertThat(result).containsExactly("COLLECTION1/20190101000000/(com,example,)/path1");
+    }
+
+    @Test
+    public void getOldestUrlTimestamp_returnsEntryWithSmallestTimestamp() {
+        List<Object> urlstimestamps = new ArrayList<>(Arrays.asList(
+                "COLLECTION1/20200101000000/(com,example,)/path1",
+                "COLLECTION1/20180101000000/(com,example,)/path2",
+                "COLLECTION1/20190101000000/(com,example,)/path3"));
+        assertThat(service.getOldestUrlTimestamp(urlstimestamps))
+                .isEqualTo("COLLECTION1/20180101000000/(com,example,)/path2");
+    }
+
+    private static QueryResponse queryResponseWithCollation(String collation) {
+        NamedList<Object> collations = new NamedList<>();
+        if (collation != null) {
+            collations.add("collation", collation);
+        }
+        NamedList<Object> spellcheck = new NamedList<>();
+        // SpellCheckResponse bails out before reading "collations" unless "suggestions" is present too
+        spellcheck.add("suggestions", new NamedList<>());
+        spellcheck.add("collations", collations);
+        NamedList<Object> response = new NamedList<>();
+        response.add("spellcheck", spellcheck);
+
+        QueryResponse queryResponse = new QueryResponse();
+        queryResponse.setResponse(response);
+        return queryResponse;
+    }
+
+    @Test
+    public void parseSuggestedQuery_returnsNullWhenNoSpellCheckResponse() {
+        QueryResponse queryResponse = new QueryResponse();
+        queryResponse.setResponse(new NamedList<>());
+        SearchQueryImpl searchQuery = new SearchQueryImpl("sapo");
+        assertThat(service.parseSuggestedQuery(queryResponse, searchQuery)).isNull();
+    }
+
+    @Test
+    public void parseSuggestedQuery_returnsNullWhenCollationMatchesOriginalQuery() {
+        SearchQueryImpl searchQuery = new SearchQueryImpl("hello");
+        QueryResponse queryResponse = queryResponseWithCollation("\"hello\"");
+        assertThat(service.parseSuggestedQuery(queryResponse, searchQuery)).isNull();
+    }
+
+    @Test
+    public void parseSuggestedQuery_stripsQuotesWeAddedOurselves() {
+        SearchQueryImpl searchQuery = new SearchQueryImpl("origanal query");
+        QueryResponse queryResponse = queryResponseWithCollation("\"original query\"");
+        assertThat(service.parseSuggestedQuery(queryResponse, searchQuery)).isEqualTo("original query");
+    }
+
+    @Test
+    public void parseSuggestedQuery_doesNotStripQuotesUserAlreadyProvided() {
+        // queryTerms is already quoted by the user, so getQuotedQueryTerms() == queryTerms and no quotes were added by us
+        SearchQueryImpl searchQuery = new SearchQueryImpl("\"origanal query\"");
+        QueryResponse queryResponse = queryResponseWithCollation("\"original query\"");
+        assertThat(service.parseSuggestedQuery(queryResponse, searchQuery)).isEqualTo("\"original query\"");
     }
 }

--- a/page-search-api/src/test/java/pt/arquivo/utils/HTTPHeaderTest.java
+++ b/page-search-api/src/test/java/pt/arquivo/utils/HTTPHeaderTest.java
@@ -1,0 +1,44 @@
+package pt.arquivo.utils;
+
+import org.apache.commons.httpclient.Header;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class HTTPHeaderTest {
+
+    @Test
+    public void getHeader_findsValueCaseInsensitively() {
+        HTTPHeader headers = new HTTPHeader();
+        headers.add(new Header("Content-Type", "text/html"));
+
+        assertThat(headers.getHeader("content-type", "default")).isEqualTo("text/html");
+        assertThat(headers.getHeader("CONTENT-TYPE", "default")).isEqualTo("text/html");
+    }
+
+    @Test
+    public void getHeader_returnsDefaultWhenHeaderMissing() {
+        HTTPHeader headers = new HTTPHeader();
+        headers.add(new Header("Content-Type", "text/html"));
+
+        assertThat(headers.getHeader("x-missing", "default")).isEqualTo("default");
+    }
+
+    @Test
+    public void addAll_appendsArrayOfHeaders() {
+        HTTPHeader headers = new HTTPHeader();
+        headers.addAll(new Header[] { new Header("A", "1"), new Header("B", "2") });
+
+        assertThat(headers).hasSize(2);
+        assertThat(headers.getHeader("a", null)).isEqualTo("1");
+        assertThat(headers.getHeader("b", null)).isEqualTo("2");
+    }
+
+    @Test
+    public void httpStatus_isSettableAndGettable() {
+        HTTPHeader headers = new HTTPHeader();
+        headers.setHttpStatus("200");
+
+        assertThat(headers.getHttpStatus()).isEqualTo("200");
+    }
+}

--- a/page-search-api/src/test/java/pt/arquivo/utils/URLNormalizersTest.java
+++ b/page-search-api/src/test/java/pt/arquivo/utils/URLNormalizersTest.java
@@ -1,0 +1,81 @@
+package pt.arquivo.utils;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class URLNormalizersTest {
+
+    @Test
+    public void stripEndingSlashes() {
+        assertThat(URLNormalizers.stripEndingSlashes("http://example.com/")).isEqualTo("http://example.com");
+        assertThat(URLNormalizers.stripEndingSlashes("http://example.com")).isEqualTo("http://example.com");
+        assertThat(URLNormalizers.stripEndingSlashes("")).isEqualTo("");
+    }
+
+    @Test
+    public void stripProtocolAndWWWUrl() {
+        assertThat(URLNormalizers.stripProtocolAndWWWUrl("http://www.example.com/path")).isEqualTo("example.com/path");
+        assertThat(URLNormalizers.stripProtocolAndWWWUrl("https://example.com")).isEqualTo("example.com");
+        assertThat(URLNormalizers.stripProtocolAndWWWUrl("www.example.com")).isEqualTo("example.com");
+        // numbered www (www2, www3, ...) variants are also stripped, and a trailing slash is dropped first
+        assertThat(URLNormalizers.stripProtocolAndWWWUrl("www2.example.com/")).isEqualTo("example.com");
+    }
+
+    @Test
+    public void canocalizeUrl() {
+        // no path gets a trailing slash added
+        assertThat(URLNormalizers.canocalizeUrl("http://example.com")).isEqualTo("http://example.com/");
+        // already-canonical URL with a path is left untouched
+        assertThat(URLNormalizers.canocalizeUrl("http://example.com/path")).isEqualTo("http://example.com/path");
+        // angle brackets are stripped, host is lowercased, path case is preserved, ending slash is dropped first
+        assertThat(URLNormalizers.canocalizeUrl("<http://EXAMPLE.com/Path/>")).isEqualTo("http://example.com/Path");
+    }
+
+    @Test
+    public void canocalizeSurtUrl() {
+        assertThat(URLNormalizers.canocalizeSurtUrl("http://www.example.com/path")).isEqualTo("(com,example,)/path");
+        // a domain-only SURT has no closing parenthesis
+        assertThat(URLNormalizers.canocalizeSurtUrl("http://www.example.com")).isEqualTo("(com,example,");
+        assertThat(URLNormalizers.canocalizeSurtUrl("http://sub.example.com/a/b")).isEqualTo("(com,example,sub,)/a/b");
+    }
+
+    @Test
+    public void surtToUrl_domainOnlyNoParens() {
+        assertThat(URLNormalizers.surtToUrl("com,example,")).isEqualTo("https://example.com/");
+    }
+
+    @Test
+    public void surtToUrl_domainOnlyWithOpenParen() {
+        // matches the actual output of canocalizeSurtUrl() for a domain with no path
+        assertThat(URLNormalizers.surtToUrl("(com,example,")).isEqualTo("https://example.com/");
+    }
+
+    @Test
+    public void surtToUrl_domainAndPath() {
+        assertThat(URLNormalizers.surtToUrl("(com,example,)/path")).isEqualTo("https://example.com/path");
+    }
+
+    @Test
+    public void surtToUrl_subdomainAndPath() {
+        assertThat(URLNormalizers.surtToUrl("(com,example,sub,)/a/b")).isEqualTo("https://sub.example.com/a/b");
+    }
+
+    @Test
+    public void surtToUrl_singleTokenWithNoCommaSlashOrParens() {
+        // a bare hostname-like string with no separators is treated as a single-component domain SURT
+        assertThat(URLNormalizers.surtToUrl("not-a-surt-plain-url.com")).isEqualTo("https://not-a-surt-plain-url.com/");
+    }
+
+    @Test
+    public void surtToUrl_invalidSurtFallsBackToTreatingInputAsUrl() {
+        // has a '/' but no '(' or ')', so it doesn't match either SURT branch and is canonicalized as-is
+        assertThat(URLNormalizers.surtToUrl("http://example.com/path")).isEqualTo("http://example.com/path");
+    }
+
+    @Test
+    public void surtToUrl_roundTripsWithCanocalizeSurtUrl() {
+        String surt = URLNormalizers.canocalizeSurtUrl("http://www.example.com/path");
+        assertThat(URLNormalizers.surtToUrl(surt)).isEqualTo("https://example.com/path");
+    }
+}


### PR DESCRIPTION
## Summary
- Add unit tests for previously untested classes in `page-search-api`: `SolrSearchService`, `CDXSearchService`, `SearchResultSerializer`, `URLNormalizers`, `ApiExceptionHandler`, `HTTPHeader`, `SERPLogging`, and `SearchResultSolrImpl`.
- Introduce Mockito (`mockito-core:5.14.2`, test-scope) to cover network/Solr-dependent code paths that were previously untestable, with a surefire `argLine` flag for JDK 25 / ByteByddy compatibility.
- Extract a small `openCdxConnection(String)` seam method in `CDXSearchService` so its HTTP fetch path can be exercised via `Mockito.spy(...)` instead of hitting the network.

## Test plan
- [x] `mvn -pl page-search-api -am test` — 101/101 tests passing, 0 failures/errors.
- [x] Full reactor `mvn -fae test` — no regressions outside the pre-existing, unrelated `page-search-indexer` JDK25/Hadoop incompatibility (dead-code module, out of scope).