### PR TITLE
ci: fix Docker build workflow for PRs and Docker Hub pushes

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -13,6 +13,7 @@ on:
     branches:
       - master
       - main
+      - development
 
 jobs:
   build:

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -27,7 +27,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Log in to Docker Hub
-        if: github.event_name != 'pull_request'
+        if: github.event_name == 'push' && contains(fromJSON('["refs/heads/master","refs/heads/main","refs/heads/development"]'), github.ref)
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -40,9 +40,10 @@ jobs:
           images: arquivo/page-search-api
           tags: |
             type=ref,event=branch
+            type=ref,event=pr
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
-            type=sha,prefix={{branch}}-
+            type=sha,prefix={{branch}}-,enable=${{ github.event_name == 'push' && contains(fromJSON('["refs/heads/master","refs/heads/main","refs/heads/development"]'), github.ref) }}
             type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Build and push Docker image
@@ -50,7 +51,7 @@ jobs:
         with:
           context: .
           file: ./page-search-api/Dockerfile
-          push: ${{ github.event_name != 'pull_request' }}
+          push: ${{ github.event_name == 'push' && contains(fromJSON('["refs/heads/master","refs/heads/main","refs/heads/development"]'), github.ref) }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha


### PR DESCRIPTION
## Summary
- Run the Docker build workflow on PRs targeting `development`, not just `master`/`main`.
- Fix invalid PR tags: `type=sha,prefix={{branch}}-` produced an invalid tag on `pull_request` events since `{{branch}}` resolves to empty there; disabled outside push-to-branch events and added `type=ref,event=pr` for PR tags.
- Restrict Docker Hub login/push to `push` events on `master`, `main`, or `development`, so tag pushes and PR builds validate without pushing to the registry.

Mirrors the same fixes applied in arquivo/image-search-api (commits 95f4714 and fbfef68).

## Test plan
- [ ] Confirm the workflow runs (without pushing) on this PR
- [ ] Confirm a push to `development`/`master`/`main` still logs in and pushes to Docker Hub