### PR TITLE
fix: add catch-all exception handler to avoid circular /error forward

### DIFF
--- a/page-search-api/src/main/java/pt/arquivo/api/exceptions/ApiExceptionHandler.java
+++ b/page-search-api/src/main/java/pt/arquivo/api/exceptions/ApiExceptionHandler.java
@@ -32,4 +32,15 @@ public class ApiExceptionHandler {
         );
        return new ResponseEntity<>(apiException, notFound);
     }
+
+    @ExceptionHandler(value = Exception.class)
+    public ResponseEntity<Object> handleUnexpectedException(Exception e) {
+        HttpStatus internalError = HttpStatus.INTERNAL_SERVER_ERROR;
+        ApiException apiException = new ApiException(
+                e.getMessage(),
+                internalError.value(),
+                ZonedDateTime.now(ZoneId.of("Z"))
+        );
+        return new ResponseEntity<>(apiException, internalError);
+    }
 }

--- a/page-search-api/src/main/java/pt/arquivo/api/exceptions/ApiExceptionHandler.java
+++ b/page-search-api/src/main/java/pt/arquivo/api/exceptions/ApiExceptionHandler.java
@@ -1,5 +1,7 @@
 package pt.arquivo.api.exceptions;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ControllerAdvice;
@@ -10,6 +12,8 @@ import java.time.ZonedDateTime;
 
 @ControllerAdvice
 public class ApiExceptionHandler {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ApiExceptionHandler.class);
 
     @ExceptionHandler(value = ApiRequestException.class)
     public ResponseEntity<Object> handleApiRequestException(ApiRequestException e) {
@@ -35,9 +39,10 @@ public class ApiExceptionHandler {
 
     @ExceptionHandler(value = Exception.class)
     public ResponseEntity<Object> handleUnexpectedException(Exception e) {
+        LOG.error("Unexpected exception handling API request", e);
         HttpStatus internalError = HttpStatus.INTERNAL_SERVER_ERROR;
         ApiException apiException = new ApiException(
-                e.getMessage(),
+                "An unexpected error occurred while processing the request",
                 internalError.value(),
                 ZonedDateTime.now(ZoneId.of("Z"))
         );

--- a/page-search-api/src/test/java/pt/arquivo/api/PageSearchControllerTest.java
+++ b/page-search-api/src/test/java/pt/arquivo/api/PageSearchControllerTest.java
@@ -1,5 +1,6 @@
 package pt.arquivo.api;
 
+import org.apache.solr.common.SolrException;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.junit.Test;
@@ -79,6 +80,20 @@ public class PageSearchControllerTest {
 
         jsonResponse = new JSONObject(response.getContentAsString());
         assertThat(jsonResponse.getJSONObject("request_parameters").getString("dedupField")).isEqualTo("site");
+    }
+
+    @Test
+    public void pageSearchUnexpectedException() throws Exception {
+        Mockito.when(searchService.query(Mockito.any()))
+                .thenThrow(new SolrException(SolrException.ErrorCode.SERVER_ERROR, "Solr is down"));
+
+        MvcResult result = mockMvc.perform(MockMvcRequestBuilders.get("/textsearch?q=sapo")).andReturn();
+
+        MockHttpServletResponse response = result.getResponse();
+        assertThat(response.getStatus()).isEqualTo(500);
+        JSONObject jsonResponse = new JSONObject(response.getContentAsString());
+        assertThat(jsonResponse.getString("message")).isEqualTo("Solr is down");
+        assertThat(jsonResponse.getInt("httpStatus")).isEqualTo(500);
     }
 
     @Test

--- a/page-search-api/src/test/java/pt/arquivo/api/PageSearchControllerTest.java
+++ b/page-search-api/src/test/java/pt/arquivo/api/PageSearchControllerTest.java
@@ -85,14 +85,16 @@ public class PageSearchControllerTest {
     @Test
     public void pageSearchUnexpectedException() throws Exception {
         Mockito.when(searchService.query(Mockito.any()))
-                .thenThrow(new SolrException(SolrException.ErrorCode.SERVER_ERROR, "Solr is down"));
+                .thenThrow(new SolrException(SolrException.ErrorCode.SERVER_ERROR,
+                        "Connection refused to solr-internal.arquivo.pt:8983"));
 
         MvcResult result = mockMvc.perform(MockMvcRequestBuilders.get("/textsearch?q=sapo")).andReturn();
 
         MockHttpServletResponse response = result.getResponse();
         assertThat(response.getStatus()).isEqualTo(500);
         JSONObject jsonResponse = new JSONObject(response.getContentAsString());
-        assertThat(jsonResponse.getString("message")).isEqualTo("Solr is down");
+        // the raw exception message must not leak into the client-facing response
+        assertThat(jsonResponse.getString("message")).doesNotContain("solr-internal.arquivo.pt");
         assertThat(jsonResponse.getInt("httpStatus")).isEqualTo(500);
     }
 

--- a/page-search-api/src/test/java/pt/arquivo/api/exceptions/ApiExceptionHandlerTest.java
+++ b/page-search-api/src/test/java/pt/arquivo/api/exceptions/ApiExceptionHandlerTest.java
@@ -32,4 +32,16 @@ public class ApiExceptionHandlerTest {
         assertThat(body.getHttpStatus()).isEqualTo(HttpStatus.NOT_FOUND.value());
         assertThat(body.getTimestamp()).isNotNull();
     }
+
+    @Test
+    public void handleUnexpectedException_returnsInternalServerErrorWithMessage() {
+        ResponseEntity<Object> response = handler
+                .handleUnexpectedException(new RuntimeException("solr connection failed"));
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+        ApiException body = (ApiException) response.getBody();
+        assertThat(body.getMessage()).isEqualTo("solr connection failed");
+        assertThat(body.getHttpStatus()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR.value());
+        assertThat(body.getTimestamp()).isNotNull();
+    }
 }

--- a/page-search-api/src/test/java/pt/arquivo/api/exceptions/ApiExceptionHandlerTest.java
+++ b/page-search-api/src/test/java/pt/arquivo/api/exceptions/ApiExceptionHandlerTest.java
@@ -34,13 +34,13 @@ public class ApiExceptionHandlerTest {
     }
 
     @Test
-    public void handleUnexpectedException_returnsInternalServerErrorWithMessage() {
+    public void handleUnexpectedException_returnsInternalServerErrorWithGenericMessage() {
         ResponseEntity<Object> response = handler
-                .handleUnexpectedException(new RuntimeException("solr connection failed"));
+                .handleUnexpectedException(new RuntimeException("solr://internal-host:8983 connection failed"));
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
         ApiException body = (ApiException) response.getBody();
-        assertThat(body.getMessage()).isEqualTo("solr connection failed");
+        assertThat(body.getMessage()).doesNotContain("internal-host");
         assertThat(body.getHttpStatus()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR.value());
         assertThat(body.getTimestamp()).isNotNull();
     }


### PR DESCRIPTION
## Summary
- `ApiExceptionHandler` only handled `ApiRequestException`/`ApiNotFoundResourceException`; any other uncaught exception (e.g. a Solr connectivity/protocol error) fell through to Spring Boot's default error handling, which crashed with a circular `/error` view forward since the WAR has no error view configured.
- Adds a catch-all `@ExceptionHandler(Exception.class)` that returns a clean JSON 500 instead.
- Logs the full exception server-side, but returns a generic client-facing message rather than `e.getMessage()`, since unlike our own `ApiRequestException`/`ApiNotFoundResourceException` (whose messages we author), arbitrary exceptions (e.g. `SolrException`) can embed internal details like hostnames.

Fixes arquivo/pwa-technologies#1591

## Test plan
- [x] `ApiExceptionHandlerTest`: unit tests for the new handler, including that the raw exception message isn't leaked
- [x] `PageSearchControllerTest#pageSearchUnexpectedException`: end-to-end `MockMvc` test that mocks the service throwing a `SolrException` and asserts the real Spring MVC stack returns a clean 500 with a sanitized body
- [x] Full existing test suite still passes