### PR TITLE
Add opt-in devtools profile for auto-reload during local dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,24 @@ $ JAVA_HOME=/usr/lib/jvm/temurin-8-jdk-amd64 mvn -f page-search-api/pom.xml spri
 By default this listens on port `8081` (see `server.port` in
 `page-search-api/src/main/resources/application.properties`).
 
+### Auto-reload on code change
+
+`spring-boot:run` alone doesn't watch your source files. To get an auto-restarting
+dev loop, opt into the `devtools` Maven profile (kept out of the default build so
+it never ends up in the production WAR — `optional=true`/`provided` scope aren't
+enough here, since the executable WAR's own launcher re-adds `provided` jars at
+runtime):
+
+`spring-boot-devtools` restarts the app whenever `target/classes` changes, but
+something still needs to recompile on save — `entr` (`sudo apt install entr`)
+reruns the compile each time a watched file changes. Both as a single command
+line, backgrounding the app and foregrounding the watcher, with a `trap` to
+stop the backgrounded app together with the watcher on Ctrl+C:
+
+```
+$ JAVA_HOME=/usr/lib/jvm/temurin-8-jdk-amd64 mvn -f page-search-api/pom.xml spring-boot:run -Pdevtools & BOOT_PID=$!; trap "kill $BOOT_PID" EXIT; find page-search-api/src/main/java -name '*.java' | entr -r mvn -f page-search-api/pom.xml compile -q -Pdevtools
+```
+
 ### Pointing at a Solr backend
 
 `searchpages.textsearch.service.bean` selects the search backend: any value other

--- a/page-search-api/pom.xml
+++ b/page-search-api/pom.xml
@@ -214,6 +214,22 @@
                 </plugins>
             </build>
         </profile>
+
+        <profile>
+            <!-- Not active by default: keeps devtools out of the war spring-boot-maven-plugin repackages
+                 for production. Opt in locally with `mvn spring-boot:run -Pdevtools`. -->
+            <id>devtools</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-devtools</artifactId>
+                    <version>2.2.4.RELEASE</version>
+                </dependency>
+            </dependencies>
+        </profile>
     </profiles>
 
     <build>


### PR DESCRIPTION
## Summary
- Adds `spring-boot-devtools` behind a non-default `devtools` Maven profile, so it can never end up in the production WAR: `optional=true`/`provided` scope alone aren't enough here, since `spring-boot-maven-plugin`'s `repackage` step re-adds `provided`-scope jars via `WEB-INF/lib-provided` for the self-contained executable WAR this project runs in Docker.
- Documents a one-line local dev workflow in the README: `mvn spring-boot:run -Pdevtools` backgrounded, with `entr` recompiling on save in the foreground so devtools restarts the app in place.

## Test plan
- [x] `mvn compile -Pdevtools` and plain `mvn compile` (profile inactive) both succeed under JDK 8